### PR TITLE
README.md Integration into About page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Status: Crate-O is now usable in Chromium-based browsers (Chrome, and Microsoft Edge work) - you can try it [here](https://language-research-technology.github.io/crate-o/), please let report bugs using Github issues in this repository.
 
-Crate-O is a browser-based editor for  Research Object Crates  ([RO-Crate]). RO-Crate is a flexible, developer-friendly approach to linked-data description and packaging. Crate-O is designed to:
+Crate-O is a browser-based editor for  Research Object Crates  [(RO-Crate)](https://www.researchobject.org/ro-crate/). RO-Crate is a flexible, developer-friendly approach to linked-data description and packaging. Crate-O is designed to:
 - describe files on a user’s computer and to add contextual information about those files
 - optionally skip the files and describe abstract contextual entities such as in a Cultural Collection or an encyclopaedia
 - annotate existing resources elsewhere on the web
@@ -11,11 +11,11 @@ Crate-O is a browser-based editor for  Research Object Crates  ([RO-Crate]). RO-
 <!---End--->
 For more technical information on Crate-O, refer to the [Developer Documentation page](./docs)
 <!---Start--->
-NOTE: Crate-O is for Google Chrome and related browsers ONLY at this stage as it describes files on the users computer, and saves RO-Crate metadata there. We will be releasing a version that can be deployed as part of a service that accesses online resources directly, which will be compatible with other browsers (see the [Roadmap]).
+NOTE: Crate-O is for Google Chrome and related browsers ONLY at this stage as it describes files on the users computer, and saves RO-Crate metadata there. We will be releasing a version that can be deployed as part of a service that accesses online resources directly, which will be compatible with other browsers (see the [Roadmap](https://github.com/Language-Research-Technology/crate-o#roadmap--backlog)).
 
-While the current version of Crate-O  is designed for editing self-contained RO-Crates (and works fine with crates containing tens of thousands of entities) - our roadmap includes editing fragments of larger linked-data resources, and integration with Arkisto repositories such as the [Oni] repository, data API & search portal.
+While the current version of Crate-O  is designed for editing self-contained RO-Crates (and works fine with crates containing tens of thousands of entities) - our roadmap includes editing fragments of larger linked-data resources, and integration with Arkisto repositories such as the [Oni](https://github.com/Language-Research-Technology/oni) repository, data API & search portal.
 
-Crate-O is currently developed by the Language Data Commons of Australia ([LDaCA]), under the guidance of Peter Sefton as technical lead. If the tool is adopted in other contexts (we are in talks with a few groups about this)  then we aim to establish a steering committee / reference group to help guide development.
+Crate-O is currently developed by the Language Data Commons of Australia [(LDaCA)](https://www.ldaca.edu.au/), under the guidance of Peter Sefton as technical lead. If the tool is adopted in other contexts (we are in talks with a few groups about this)  then we aim to establish a steering committee / reference group to help guide development.
 <!---End--->
 # History
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-
+<!---Start--->
 # Crate-O
 
 Status: Crate-O is now usable in Chromium-based browsers (Chrome, and Microsoft Edge work) - you can try it [here](https://language-research-technology.github.io/crate-o/), please let report bugs using Github issues in this repository.
@@ -8,15 +8,15 @@ Crate-O is a browser-based editor for  Research Object Crates  ([RO-Crate]). RO-
 - optionally skip the files and describe abstract contextual entities such as in a Cultural Collection or an encyclopaedia
 - annotate existing resources elsewhere on the web
 - import bulk metadata from an Excel spreadsheet
-
+<!---End--->
 For more technical information on Crate-O, refer to the [Developer Documentation page](./docs)
-
+<!---Start--->
 NOTE: Crate-O is for Google Chrome and related browsers ONLY at this stage as it describes files on the users computer, and saves RO-Crate metadata there. We will be releasing a version that can be deployed as part of a service that accesses online resources directly, which will be compatible with other browsers (see the [Roadmap]).
 
 While the current version of Crate-O  is designed for editing self-contained RO-Crates (and works fine with crates containing tens of thousands of entities) - our roadmap includes editing fragments of larger linked-data resources, and integration with Arkisto repositories such as the [Oni] repository, data API & search portal.
 
 Crate-O is currently developed by the Language Data Commons of Australia ([LDaCA]), under the guidance of Peter Sefton as technical lead. If the tool is adopted in other contexts (we are in talks with a few groups about this)  then we aim to establish a steering committee / reference group to help guide development.
-
+<!---End--->
 # History
 
 Crate-O was is a rewrite of a tool called [Describo]. Though members of the Crate-O tool were involved in its conception, funding and development we are no longer associated with that line of development.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crate-o",
-  "version": "0.3.8",
+  "version": "0.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crate-o",
-      "version": "0.3.8",
+      "version": "0.3.10",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@element-plus/icons-vue": "^2.3.1",
@@ -14,6 +14,7 @@
         "leaflet-editable": "^1.2.0",
         "leaflet-gesture-handling": "^1.2.2",
         "leaflet.path.drag": "^0.0.6",
+        "marked": "^12.0.2",
         "mime": "^4.0.1",
         "ro-crate": "^3.3.9"
       },
@@ -4289,6 +4290,17 @@
       "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
+      }
+    },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mdurl": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "leaflet-editable": "^1.2.0",
     "leaflet-gesture-handling": "^1.2.2",
     "leaflet.path.drag": "^0.0.6",
+    "marked": "^12.0.2",
     "mime": "^4.0.1",
     "ro-crate": "^3.3.9"
   },

--- a/src/app/components/About.vue
+++ b/src/app/components/About.vue
@@ -5,7 +5,7 @@ fetch('./README.md')
       .then(response => response.text())
       .then(markdown => {
         const htmlContent = marked(slice_anchors(markdown));
-        document.getElementById("htmlContent").innerHTML = htmlContent;
+        document.getElementById("about_html_content").innerHTML = htmlContent;
       })
       .catch(error => console.error('Error fetching the Markdown file:', error))
 
@@ -36,68 +36,34 @@ function slice_anchors(markdown) {
 //TODO: Insert code that will load the readme markdown into here as html
 </script>
 <style>
-  h1 {
-    @apply mb-3 text-xl md:text-xl
+  #about_html_content h1 {
+    @apply mb-3 text-xl md:text-xl text-gray-500
   }
-  h2 {
-    @apply mb-3 text-lg md:text-xl
+  #about_html_content h2 {
+    @apply mb-3 text-lg md:text-xl text-gray-500
   }
-  div {
-    @apply grid gap-2 text-gray-500 dark:text-gray-400
+  #about_html_content div {
+    @apply grid gap-2 text-gray-500 dark:text-gray-400 grid gap-2
   }
-  a {
+  #about_html_content a {
     @apply text-blue-600 dark:text-blue-500 hover:underline
   }
-  ul {
-    @apply list-disc list-inside
+  #about_html_content ul {
+    @apply list-disc list-inside text-gray-500
+  }
+  #about_html_content p {
+    @apply text-gray-500
   }
 </style>
 <template>
-  <div id="htmlContent"></div>
+  <div class="grid gap-2 text-gray-500 dark:text-gray-400" id="about_html_content"></div>
   <div class="grid gap-2 text-gray-500 dark:text-gray-400">
-    
-
-    <h2 class="mb-3 text-lg md:text-xl">About Crate-O</h2>
+    <br>
     <p class="">
-      Crate-O is a browser-based editor for <a class="text-blue-600 dark:text-blue-500 hover:underline"
-        href="https://www.researchobject.org/ro-crate" target="_blank" rel="noopener noreferrer">Research Object Crates
-        (RO-Crate)</a>.
-      RO-Crate is a flexible,
-      developer-friendly approach to linked-data description and packaging.
-    </p>
-    <p class="">Crate-O is designed to:</p>
-    <ul class="list-disc list-inside">
-      <li>describe files on a user’s computer and to add contextual information about those files,</li>
-      <li>skip the files and describe abstract contextual entities such as in a Cultural Collection or an encyclopaedia,
-        or</li>
-      <li>annotate existing resources elsewhere on the web.</li>
-    </ul>
-    
-    <p class="">
-      Crate-O works only with <a class="text-blue-600 dark:text-blue-500 hover:underline"
-        href="https://google.com/chrome" target="_blank" rel="noopener noreferrer">Google
-        Chrome</a> and <a class="text-blue-600 dark:text-blue-500 hover:underline" href="https://microsoft.com/edge"
-        target="_blank" rel="noopener noreferrer">Microsoft Edge</a> at this stage as it
-      describes files on the user's
-      computer, and saves RO-Crate metadata there. We will be releasing versions that work with online resources
-      directly which will be compatible with other browsers (see the
+      <!-- I don't know why these hidden links are needed but they are -->
       <a class="text-blue-600 dark:text-blue-500 hover:underline"
-        href="https://github.com/Language-Research-Technology/crate-o#roadmap--backlog" target="_blank"
-        rel="noopener noreferrer">Roadmap</a>).
-    </p>
-    <p class="">
-      While the current version of Crate-O is designed for editing self-contained RO-Crates (and works fine with
-      crates
-      containing tens of thousands of entities) - our roadmap includes editing fragments of larger linked-data
-      resources,
-      and integration with Arkisto repositories such as the Oni repository, data API and search portal.
-    </p>
-    <p class="">
-      Crate-O is currently developed by the <a class="text-blue-600 dark:text-blue-500 hover:underline"
-        href="https://www.ldaca.edu.au/" target="_blank" rel="noopener noreferrer">Language Data Commons of Australia
-        (LDaCA)</a>, under the guidance of
-      Peter Sefton as technical lead. If the tool is adopted in other contexts (we are in talks with a few groups
-      about this) then we aim to establish a steering committee/reference group to help guide development.
+        href="ldaca.edu.au" target="_blank" rel="noopener noreferrer"></a><a class="text-blue-600 dark:text-blue-500 hover:underline" href="https://www.ldaca.edu.au/"
+        target="_blank" rel="noopener noreferrer"></a>
     </p>
   </div>
 </template>

--- a/src/app/components/About.vue
+++ b/src/app/components/About.vue
@@ -1,9 +1,62 @@
 <script setup>
+import { marked } from 'marked';
+
+fetch('./README.md')
+      .then(response => response.text())
+      .then(markdown => {
+        const htmlContent = marked(slice_anchors(markdown));
+        document.getElementById("htmlContent").innerHTML = htmlContent;
+      })
+      .catch(error => console.error('Error fetching the Markdown file:', error))
+
+// Finds indexes of substrings in string
+function indexes(substring, string){
+  var a=[],i=-1;
+  while((i=string.indexOf(substring,i+1)) >= 0) {
+    substring.includes("Start") ? a.push([i + 14]) : a.push(i);
+  }
+  return a;
+}
+
+function slice_anchors(markdown) {
+  var starts = indexes("<!---Start--->", markdown);
+  var ends = indexes("<!---End--->", markdown);
+  var md_sliced = "";
+  try {
+    for (let i = 0; i < starts.length; i++) {
+      console.log("md slice from ", starts[i], " to ", ends[i], ": ", markdown.slice(starts[i], ends[i]))
+      md_sliced += markdown.slice(starts[i], ends[i]);
+    }
+    return md_sliced;
+  } catch(err) {
+    console.log(err);
+  }
+}
 
 //TODO: Insert code that will load the readme markdown into here as html
 </script>
+<style>
+  h1 {
+    @apply mb-3 text-xl md:text-xl
+  }
+  h2 {
+    @apply mb-3 text-lg md:text-xl
+  }
+  div {
+    @apply grid gap-2 text-gray-500 dark:text-gray-400
+  }
+  a {
+    @apply text-blue-600 dark:text-blue-500 hover:underline
+  }
+  ul {
+    @apply list-disc list-inside
+  }
+</style>
 <template>
+  <div id="htmlContent"></div>
   <div class="grid gap-2 text-gray-500 dark:text-gray-400">
+    
+
     <h2 class="mb-3 text-lg md:text-xl">About Crate-O</h2>
     <p class="">
       Crate-O is a browser-based editor for <a class="text-blue-600 dark:text-blue-500 hover:underline"


### PR DESCRIPTION
PR for issue #136
Line 64 of About.vue (the contentless links) is required for it to be displayed and I'm not sure why, is this a problem?